### PR TITLE
add FixedPointClass

### DIFF
--- a/Parseq/FixedPoint.cs
+++ b/Parseq/FixedPoint.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Parseq
+{
+	public class FixedPoint<TToken,T>
+	{
+		private Parser<TToken, T> _fixedParser;
+		public Parser<TToken, T> FixedParser
+		{
+			set
+			{
+				if (value == null) throw new NullReferenceException();
+				if (_fixedParser != null) throw new InvalidOperationException("Parser is already registered.");
+				_fixedParser = value;
+
+			}
+		}
+
+		public IReply<TToken, T> Parse(ITokenStream<TToken> stream)
+		{
+			if (_fixedParser == null) throw new InvalidOperationException("Parser isn't registered.");
+			return _fixedParser(stream);
+		}
+	}
+}

--- a/Parseq/Parseq.csproj
+++ b/Parseq/Parseq.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Delayed.Extensions.cs" />
     <Compile Include="Either.cs" />
     <Compile Include="Either.Extensions.cs" />
+    <Compile Include="FixedPoint.cs" />
     <Compile Include="Option.cs" />
     <Compile Include="Option.Extensions.cs" />
     <Compile Include="Pair.cs" />

--- a/Test/FixedPointTest.cs
+++ b/Test/FixedPointTest.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Parseq;
+
+using static Parseq.Combinators.Chars;
+using static Parseq.Combinator; 
+
+namespace Test.Parseq
+{
+	[TestFixture]
+	public class FixedPointTest
+	{
+		[TestCase]
+		public void NullSetTest()
+		{
+			var fix = new FixedPoint<char, char>();
+			Assert.Throws<NullReferenceException>(() => { fix.FixedParser = null; });
+		}
+
+		[TestCase]
+		public void DuplicateSetTest()
+		{
+			var fix = new FixedPoint<char, char> {FixedParser = Char('n')};
+
+			Assert.Throws<InvalidOperationException>(() => { fix.FixedParser = Char('o'); });
+
+
+			Assert.IsTrue(fix.Parse("n".AsStream()).Case(_ => false, _ => true));
+			Assert.IsFalse(fix.Parse("o".AsStream()).Case(_ => false, _ => true));
+		}
+
+		[TestCase]
+		public void UnsettedCallTest()
+		{
+			var fix = new FixedPoint<char, char>();
+
+			Assert.Throws<InvalidOperationException>(() => { fix.Parse("n".AsStream()); });
+		}
+
+		[TestCase]
+		public void TypicalUseCaseTest()
+		{
+			var fix = new FixedPoint<char, IEnumerable<char>>();
+
+			//digit<-[0-9]
+			var digit = Digit().Select(c => new[] {c});
+
+			//field<-digit/collection
+			var field = Choice(digit, fix.Parse);
+
+
+			var tmp = (from f in field
+				from _ in Char(',')
+				select f).Many0();
+
+			//fields<-(field ",")* field
+			var fields = from f in tmp
+				from n in field
+				select f.SelectMany(c => c).Concat(n);
+
+			//collection<-"{" fields? "}"
+			var collection = from _ in Char('{')
+				from f in fields.Optional()
+				from __ in Char('}')
+				select new[] {'{'}.Concat(f.HasValue ? f.Value : new char[0]).Concat(new[] {'}'});
+
+			fix.FixedParser = collection;
+
+			Assert.IsTrue(collection.Run("{}".AsStream()).Case(_ => false, act => act.SequenceEqual("{}")));
+			Assert.IsTrue(collection.Run("{1,2,3}".AsStream()).Case(_ => false, act => act.SequenceEqual("{123}")));
+			Assert.IsTrue(collection.Run("{1,2,{3,4},5}".AsStream()).Case(_ => false, act => act.SequenceEqual("{12{34}5}")));
+			Assert.IsTrue(collection.Run("{{}}".AsStream()).Case(_ => false, act => act.SequenceEqual("{{}}")));
+
+
+
+		}
+	}
+}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -32,8 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -43,10 +44,8 @@
     <Compile Include="Combinator.Test.cs" />
     <Compile Include="Combinators\Chars.Test.cs" />
     <Compile Include="Combinators\Prims.Test.cs" />
+    <Compile Include="FixedPointTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Parseq\Parseq.csproj">
@@ -56,6 +55,9 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Test/packages.config
+++ b/Test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.6.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
add FixedPointTests
update nunit.framework ver2.6.4 to ver3.6.0

四則演算とかのパーサ組むときに使いがちなパーサ間で相互再帰させる際の不動点を作ってみました｡
典型的な使用例は､FixedPointTest.csに記載されております｡

また､テストフレームワークが旨く作動しなかったので､nunit.frameworkをversion2.6.4からversion3.6.0にアップデートしております｡
